### PR TITLE
Add initial part of CPP wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# build artifacts
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.25)
+project(tidesdb_cpp CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(PROJECT_VERSION 0.1.0)
+add_compile_options(-Wextra -Wall -Werror)
+
+find_library(LIBRARY_TIDEDB NAMES tidesdb)
+
+add_library(tidesdb_cpp SHARED tidesdb-cpp.cpp)
+target_link_libraries(tidesdb_cpp PUBLIC ${LIBRARY_TIDEDB})
+
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+enable_testing()
+
+add_executable(tests test/tests.cpp)
+target_link_libraries(tests GTest::gtest_main tidesdb_cpp ${LIBRARY_TIDEDB})
+
+include(GoogleTest)
+gtest_discover_tests(tests)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -1,0 +1,109 @@
+/*
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Evgeny Kornev
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../tidesdb-cpp.hpp"
+#include <gtest/gtest.h>
+
+const char* column_name = "my_db";
+const char* key = "key";
+const char* value = "value";
+const int flush_threshold = (1024 * 1024) * 128;
+const tidesdb_compression_algo_t compression_algo = TDB_COMPRESS_SNAPPY;
+const float probability = TDB_USING_HT_PROBABILITY;
+const int max_level = TDB_USING_HT_MAX_LEVEL;
+const bool bloom_filter = true;
+const bool compressed = true;
+const tidesdb_memtable_ds_t memtable_ds = TDB_MEMTABLE_HASH_TABLE;
+
+TEST(TidesDB, Open_and_Close) {
+	Tidesdb db;
+	EXPECT_EQ(db.open("tmp") , 0);
+	EXPECT_EQ(db.close() , 0);
+}
+TEST(TidesDB, Create_and_Drop_Column_Family) {
+	Tidesdb db;
+	EXPECT_EQ(db.open("tmp") , 0);
+	EXPECT_EQ(db.create_column_family(column_name,
+				          flush_threshold,
+				          max_level,
+				          probability,
+				          bloom_filter,
+				          compression_algo,
+				          compressed,
+				          memtable_ds) , 0);
+	EXPECT_EQ(db.drop_column_family(column_name) , 0);
+	EXPECT_EQ(db.close() , 0);
+}
+
+TEST(TidesDB, Create_and_Column_Family_and_Put) {
+	Tidesdb db;
+	EXPECT_EQ(db.open("tmp") , 0);
+	EXPECT_EQ(db.create_column_family(column_name,
+				          flush_threshold,
+				          max_level,
+				          probability,
+				          bloom_filter,
+				          compression_algo,
+				          compressed,
+				          memtable_ds) , 0);
+	EXPECT_EQ(db.put(column_name, (const uint8_t*)key, (const uint8_t*)value, -1), 0);
+	EXPECT_EQ(db.drop_column_family(column_name) , 0);
+	EXPECT_EQ(db.close() , 0);
+}
+
+TEST(TidesDB, Put_and_Get) {
+	Tidesdb db;
+	uint8_t * got_value = nullptr;
+	size_t got_value_size = 0;
+	EXPECT_EQ(db.open("tmp") , 0);
+	EXPECT_EQ(db.create_column_family(column_name,
+				          flush_threshold,
+				          max_level,
+				          probability,
+				          bloom_filter,
+				          compression_algo,
+				          compressed,
+				          memtable_ds) , 0);
+	EXPECT_EQ(db.put(column_name, (const uint8_t*)key, (const uint8_t*)value, -1), 0);
+	EXPECT_EQ(db.get(column_name, (const uint8_t*)key, &got_value, got_value_size), 0);
+	EXPECT_STREQ(value, (const char*)got_value);
+	EXPECT_EQ(db.drop_column_family(column_name) , 0);
+	EXPECT_EQ(db.close() , 0);
+}
+
+TEST(TidesDB, Put_and_Delete) {
+	Tidesdb db;
+	uint8_t * got_value = nullptr;
+	size_t got_value_size = 0;
+	EXPECT_EQ(db.open("tmp") , 0);
+	EXPECT_EQ(db.create_column_family(column_name,
+				          flush_threshold,
+				          max_level,
+				          probability,
+				          bloom_filter,
+				          compression_algo,
+				          compressed,
+				          memtable_ds) , 0);
+	EXPECT_EQ(db.put(column_name, (const uint8_t*)key, (const uint8_t*)value, -1), 0);
+	EXPECT_EQ(db.delete_key(column_name, (const uint8_t*)key), 0);
+	EXPECT_NE(db.get(column_name, (const uint8_t*)key, &got_value, got_value_size), 0);
+	EXPECT_EQ(db.drop_column_family(column_name) , 0);
+	EXPECT_EQ(db.close() , 0);
+}
+

--- a/tidesdb-cpp.cpp
+++ b/tidesdb-cpp.cpp
@@ -1,0 +1,112 @@
+/*
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Evgeny Kornev
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include "tidesdb-cpp.hpp"
+#include <tidesdb.h>
+
+#define ERR_HANDLER()                                    \
+        if(err) {                                        \
+                std::cout << err->message << std::endl;  \
+                int err_code = err->code;                \
+                tidesdb_err_free(err);                   \
+                return err_code;                         \
+        }                                                \
+        return 0;                                        \
+
+Tidesdb::Tidesdb(void) {
+        tbh = nullptr;
+}
+
+int Tidesdb::open(const char* dir_name) {
+        tidesdb_err_t* err = tidesdb_open(dir_name, &this->tbh);
+        ERR_HANDLER()
+}
+
+int Tidesdb::close() {
+        tidesdb_err_t* err = tidesdb_close(this->tbh);
+        ERR_HANDLER()
+}
+int Tidesdb::create_column_family(const char *column_family_name, int flush_threshold,
+                                  int max_level, float probability, bool compressed,
+                                  tidesdb_compression_algo_t compress_algo,
+                                  bool bloom_filter, tidesdb_memtable_ds_t memtable_ds) {
+	tidesdb_err_t *err = tidesdb_create_column_family(this->tbh,
+                                                          column_family_name,
+                                                          flush_threshold,
+                                                          max_level,
+                                                          probability,
+                                                          compressed,
+                                                          compress_algo,
+                                                          bloom_filter,
+                                                          memtable_ds);
+        ERR_HANDLER()
+}
+
+int Tidesdb::drop_column_family(const char *column_family_name) {
+	tidesdb_err_t *err = tidesdb_drop_column_family(this->tbh,
+                                                        column_family_name);
+        ERR_HANDLER()
+}
+
+int Tidesdb::put(const char *column_family_name,
+                 const uint8_t *key,
+                 const uint8_t *value,
+                 time_t ttl) {
+
+        size_t key_size = strlen((const char*)key);
+        size_t value_size = strlen((const char*)value);
+	tidesdb_err_t *err = tidesdb_put(this->tbh,
+                                         column_family_name,
+                                         key,
+                                         key_size,
+                                         value,
+                                         value_size,
+                                         ttl);
+        ERR_HANDLER()
+}
+
+int Tidesdb::get(const char *column_family_name,
+                 const uint8_t *key,
+                 uint8_t **value,
+                 size_t &value_size) {
+        size_t key_size = strlen((const char*)key);
+	tidesdb_err_t *err = tidesdb_get(this->tbh,
+                                         column_family_name,
+                                         key,
+                                         key_size,
+                                         value,
+                                         &value_size);
+        if(err == nullptr) {
+                uint8_t* buf = *value;
+                buf[value_size] = 0;
+        }
+        ERR_HANDLER()
+}
+
+int Tidesdb::delete_key(const char *column_family_name,
+                 const uint8_t *key) {
+        size_t key_size = strlen((const char*)key);
+	tidesdb_err_t *err = tidesdb_delete(this->tbh,
+                                            column_family_name,
+                                            key,
+                                            key_size);
+        ERR_HANDLER()
+}
+

--- a/tidesdb-cpp.hpp
+++ b/tidesdb-cpp.hpp
@@ -1,0 +1,46 @@
+/*
+ *
+ * Copyright (C) TidesDB
+ *
+ * Original Author: Evgeny Kornev
+ *
+ * Licensed under the Mozilla Public License, v. 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <tidesdb.h>
+
+#pragma once
+
+class Tidesdb {
+        tidesdb_t* tbh;
+public:
+        int open(const char* dir_name);
+        int close();
+	int create_column_family(const char *name, int flush_threshold,
+                                            int max_level, float probability, bool compressed,
+                                            tidesdb_compression_algo_t compress_algo,
+                                            bool bloom_filter, tidesdb_memtable_ds_t memtable_ds);
+        int drop_column_family(const char *name);
+        int put(const char *column_family_name,
+                const uint8_t *key,
+                const uint8_t *value,
+                time_t ttl);
+        int get(const char *column_family_name,
+                const uint8_t *key,
+                uint8_t **value,
+                size_t &value_size);
+        int delete_key(const char *column_family_name,
+                       const uint8_t *key);
+        Tidesdb();
+};
+


### PR DESCRIPTION
The following APIs are supported:

*tidesdb_open
*tidesdb_close
*create_column_family
*drop_column_family
*tidesdb_put
*tidesdb_get
*tidesdb_delete

Add Google framework tests for wrapper
APIs

tests could be run by

cd build && ctest