### PR TITLE
add missing features from latest tidesdb: unified memtable config, db…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(tidesdb_cpp VERSION 2.3.5 LANGUAGES CXX)
+project(tidesdb_cpp VERSION 2.3.6 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/tidesdb/tidesdb.hpp
+++ b/include/tidesdb/tidesdb.hpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 extern "C"
@@ -102,7 +103,8 @@ enum class ErrorCode
     MemoryLimit = TDB_ERR_MEMORY_LIMIT,
     InvalidDB = TDB_ERR_INVALID_DB,
     Unknown = TDB_ERR_UNKNOWN,
-    Locked = TDB_ERR_LOCKED
+    Locked = TDB_ERR_LOCKED,
+    Readonly = TDB_ERR_READONLY
 };
 
 /**
@@ -149,6 +151,8 @@ class Exception : public std::runtime_error
                 return "invalid database handle";
             case TDB_ERR_LOCKED:
                 return "database is locked";
+            case TDB_ERR_READONLY:
+                return "database is read-only";
             default:
                 return "unknown error";
         }
@@ -190,8 +194,11 @@ struct ColumnFamilyConfig
     int l0QueueStallThreshold = 20;
     bool useBtree = false;  ///< Use B+tree format for klog (default: false = block-based)
     tidesdb_commit_hook_fn commitHookFn =
-        nullptr;                    ///< Optional commit hook callback (runtime-only)
-    void* commitHookCtx = nullptr;  ///< Optional user context for commit hook (runtime-only)
+        nullptr;                           ///< Optional commit hook callback (runtime-only)
+    void* commitHookCtx = nullptr;         ///< Optional user context for commit hook (runtime-only)
+    std::size_t objectTargetFileSize = 0;  ///< Target SSTable size in object store mode (0=auto)
+    int objectLazyCompaction = 0;          ///< 1 = compact less aggressively in object store mode
+    int objectPrefetchCompaction = 1;      ///< 1 = download all inputs before merge
 
     /**
      * @brief Get default column family configuration from TidesDB
@@ -231,6 +238,13 @@ struct Config
     bool logToFile = false;
     std::size_t logTruncationAt = 24 * 1024 * 1024;
     std::size_t maxMemoryUsage = 0;  ///< Global memory limit in bytes (0 = auto)
+    bool unifiedMemtable = false;    ///< Enable unified memtable mode (default: per-CF memtables)
+    std::size_t unifiedMemtableWriteBufferSize =
+        0;                                    ///< Unified memtable write buffer size (0 = auto)
+    int unifiedMemtableSkipListMaxLevel = 0;  ///< Skip list max level (0 = default 12)
+    float unifiedMemtableSkipListProbability = 0;  ///< Skip list probability (0 = default 0.25)
+    SyncMode unifiedMemtableSyncMode = SyncMode::None;  ///< Sync mode for unified WAL
+    std::uint64_t unifiedMemtableSyncIntervalUs = 0;    ///< Sync interval for unified WAL
 };
 
 /**
@@ -276,6 +290,22 @@ struct DbStats
     std::int64_t txnMemoryBytes = 0;
     std::size_t compactionQueueSize = 0;
     std::size_t flushQueueSize = 0;
+    bool unifiedMemtableEnabled = false;
+    std::int64_t unifiedMemtableBytes = 0;
+    int unifiedImmutableCount = 0;
+    bool unifiedIsFlushing = false;
+    std::uint32_t unifiedNextCfIndex = 0;
+    std::uint64_t unifiedWalGeneration = 0;
+    bool objectStoreEnabled = false;
+    std::string objectStoreConnector;
+    std::size_t localCacheBytesUsed = 0;
+    std::size_t localCacheBytesMax = 0;
+    int localCacheNumFiles = 0;
+    std::uint64_t lastUploadedGeneration = 0;
+    std::size_t uploadQueueDepth = 0;
+    std::uint64_t totalUploads = 0;
+    std::uint64_t totalUploadFailures = 0;
+    bool replicaMode = false;
 };
 
 /**
@@ -458,6 +488,12 @@ class Iterator
      */
     [[nodiscard]] std::vector<std::uint8_t> value() const;
 
+    /**
+     * @brief Get the current key and value in a single call
+     * @return Pair of key and value byte vectors
+     */
+    [[nodiscard]] std::pair<std::vector<std::uint8_t>, std::vector<std::uint8_t>> keyValue() const;
+
    private:
     friend class Transaction;
     explicit Iterator(tidesdb_iter_t* iter) : iter_(iter)
@@ -595,10 +631,16 @@ class TidesDB
     void createColumnFamily(const std::string& name, const ColumnFamilyConfig& config);
 
     /**
-     * @brief Drop a column family
+     * @brief Drop a column family by name
      * @param name Column family name
      */
     void dropColumnFamily(const std::string& name);
+
+    /**
+     * @brief Delete a column family by handle (faster when you already hold a handle)
+     * @param cf Column family handle
+     */
+    void deleteColumnFamily(ColumnFamily& cf);
 
     /**
      * @brief Get a column family by name
@@ -690,6 +732,11 @@ class TidesDB
      * column family that fails.
      */
     void purge();
+
+    /**
+     * @brief Switch a read-only replica to primary mode
+     */
+    void promoteToPrimary();
 
     /**
      * @brief Get default database configuration

--- a/src/tidesdb.cpp
+++ b/src/tidesdb.cpp
@@ -69,6 +69,9 @@ ColumnFamilyConfig ColumnFamilyConfig::defaultConfig()
     config.l1FileCountTrigger = cConfig.l1_file_count_trigger;
     config.l0QueueStallThreshold = cConfig.l0_queue_stall_threshold;
     config.useBtree = cConfig.use_btree != 0;
+    config.objectTargetFileSize = cConfig.object_target_file_size;
+    config.objectLazyCompaction = cConfig.object_lazy_compaction;
+    config.objectPrefetchCompaction = cConfig.object_prefetch_compaction;
 
     return config;
 }
@@ -103,6 +106,9 @@ ColumnFamilyConfig ColumnFamilyConfig::loadFromIni(const std::string& iniFile,
     config.l1FileCountTrigger = cConfig.l1_file_count_trigger;
     config.l0QueueStallThreshold = cConfig.l0_queue_stall_threshold;
     config.useBtree = cConfig.use_btree != 0;
+    config.objectTargetFileSize = cConfig.object_target_file_size;
+    config.objectLazyCompaction = cConfig.object_lazy_compaction;
+    config.objectPrefetchCompaction = cConfig.object_prefetch_compaction;
 
     return config;
 }
@@ -133,6 +139,9 @@ void ColumnFamilyConfig::saveToIni(const std::string& iniFile, const std::string
     cConfig.l1_file_count_trigger = config.l1FileCountTrigger;
     cConfig.l0_queue_stall_threshold = config.l0QueueStallThreshold;
     cConfig.use_btree = config.useBtree ? 1 : 0;
+    cConfig.object_target_file_size = config.objectTargetFileSize;
+    cConfig.object_lazy_compaction = config.objectLazyCompaction;
+    cConfig.object_prefetch_compaction = config.objectPrefetchCompaction;
 
     std::memset(cConfig.comparator_name, 0, TDB_MAX_COMPARATOR_NAME);
     if (!config.comparatorName.empty())
@@ -246,6 +255,9 @@ Stats ColumnFamily::getStats() const
         cfConfig.l1FileCountTrigger = cStats->config->l1_file_count_trigger;
         cfConfig.l0QueueStallThreshold = cStats->config->l0_queue_stall_threshold;
         cfConfig.useBtree = cStats->config->use_btree != 0;
+        cfConfig.objectTargetFileSize = cStats->config->object_target_file_size;
+        cfConfig.objectLazyCompaction = cStats->config->object_lazy_compaction;
+        cfConfig.objectPrefetchCompaction = cStats->config->object_prefetch_compaction;
         stats.config = cfConfig;
     }
 
@@ -343,6 +355,9 @@ void ColumnFamily::updateRuntimeConfig(const ColumnFamilyConfig& config, bool pe
     cConfig.l1_file_count_trigger = config.l1FileCountTrigger;
     cConfig.l0_queue_stall_threshold = config.l0QueueStallThreshold;
     cConfig.use_btree = config.useBtree ? 1 : 0;
+    cConfig.object_target_file_size = config.objectTargetFileSize;
+    cConfig.object_lazy_compaction = config.objectLazyCompaction;
+    cConfig.object_prefetch_compaction = config.objectPrefetchCompaction;
 
     std::memset(cConfig.comparator_name, 0, TDB_MAX_COMPARATOR_NAME);
     if (!config.comparatorName.empty())
@@ -464,6 +479,20 @@ std::vector<std::uint8_t> Iterator::value() const
 
     std::vector<std::uint8_t> valueVec(valueData, valueData + valueSize);
     return valueVec;
+}
+
+std::pair<std::vector<std::uint8_t>, std::vector<std::uint8_t>> Iterator::keyValue() const
+{
+    uint8_t* keyData = nullptr;
+    size_t keySize = 0;
+    uint8_t* valueData = nullptr;
+    size_t valueSize = 0;
+
+    int result = tidesdb_iter_key_value(iter_, &keyData, &keySize, &valueData, &valueSize);
+    checkResult(result, "failed to get key-value");
+
+    return {std::vector<std::uint8_t>(keyData, keyData + keySize),
+            std::vector<std::uint8_t>(valueData, valueData + valueSize)};
 }
 
 //-----------------------------------------------------------------------------
@@ -615,6 +644,14 @@ TidesDB::TidesDB(const Config& config)
     cConfig.log_to_file = config.logToFile ? 1 : 0;
     cConfig.log_truncation_at = config.logTruncationAt;
     cConfig.max_memory_usage = config.maxMemoryUsage;
+    cConfig.unified_memtable = config.unifiedMemtable ? 1 : 0;
+    cConfig.unified_memtable_write_buffer_size = config.unifiedMemtableWriteBufferSize;
+    cConfig.unified_memtable_skip_list_max_level = config.unifiedMemtableSkipListMaxLevel;
+    cConfig.unified_memtable_skip_list_probability = config.unifiedMemtableSkipListProbability;
+    cConfig.unified_memtable_sync_mode = static_cast<int>(config.unifiedMemtableSyncMode);
+    cConfig.unified_memtable_sync_interval_us = config.unifiedMemtableSyncIntervalUs;
+    cConfig.object_store = nullptr;
+    cConfig.object_store_config = nullptr;
 
     int result = tidesdb_open(&cConfig, &db_);
     checkResult(result, "failed to open database");
@@ -673,6 +710,9 @@ void TidesDB::createColumnFamily(const std::string& name, const ColumnFamilyConf
     cConfig.l1_file_count_trigger = config.l1FileCountTrigger;
     cConfig.l0_queue_stall_threshold = config.l0QueueStallThreshold;
     cConfig.use_btree = config.useBtree ? 1 : 0;
+    cConfig.object_target_file_size = config.objectTargetFileSize;
+    cConfig.object_lazy_compaction = config.objectLazyCompaction;
+    cConfig.object_prefetch_compaction = config.objectPrefetchCompaction;
 
     std::memset(cConfig.comparator_name, 0, TDB_MAX_COMPARATOR_NAME);
     if (!config.comparatorName.empty())
@@ -694,6 +734,13 @@ void TidesDB::dropColumnFamily(const std::string& name)
 {
     int result = tidesdb_drop_column_family(db_, name.c_str());
     checkResult(result, "failed to drop column family");
+}
+
+void TidesDB::deleteColumnFamily(ColumnFamily& cf)
+{
+    int result = tidesdb_delete_column_family(db_, cf.handle());
+    checkResult(result, "failed to delete column family");
+    cf.cf_ = nullptr;
 }
 
 ColumnFamily TidesDB::getColumnFamily(const std::string& name)
@@ -766,6 +813,22 @@ DbStats TidesDB::getDbStats()
     stats.txnMemoryBytes = cStats.txn_memory_bytes;
     stats.compactionQueueSize = cStats.compaction_queue_size;
     stats.flushQueueSize = cStats.flush_queue_size;
+    stats.unifiedMemtableEnabled = cStats.unified_memtable_enabled != 0;
+    stats.unifiedMemtableBytes = cStats.unified_memtable_bytes;
+    stats.unifiedImmutableCount = cStats.unified_immutable_count;
+    stats.unifiedIsFlushing = cStats.unified_is_flushing != 0;
+    stats.unifiedNextCfIndex = cStats.unified_next_cf_index;
+    stats.unifiedWalGeneration = cStats.unified_wal_generation;
+    stats.objectStoreEnabled = cStats.object_store_enabled != 0;
+    stats.objectStoreConnector = cStats.object_store_connector ? cStats.object_store_connector : "";
+    stats.localCacheBytesUsed = cStats.local_cache_bytes_used;
+    stats.localCacheBytesMax = cStats.local_cache_bytes_max;
+    stats.localCacheNumFiles = cStats.local_cache_num_files;
+    stats.lastUploadedGeneration = cStats.last_uploaded_generation;
+    stats.uploadQueueDepth = cStats.upload_queue_depth;
+    stats.totalUploads = cStats.total_uploads;
+    stats.totalUploadFailures = cStats.total_upload_failures;
+    stats.replicaMode = cStats.replica_mode != 0;
 
     return stats;
 }
@@ -832,6 +895,12 @@ void TidesDB::purge()
     checkResult(result, "failed to purge database");
 }
 
+void TidesDB::promoteToPrimary()
+{
+    int result = tidesdb_promote_to_primary(db_);
+    checkResult(result, "failed to promote to primary");
+}
+
 Config TidesDB::defaultConfig()
 {
     tidesdb_config_t cConfig = tidesdb_default_config();
@@ -846,6 +915,12 @@ Config TidesDB::defaultConfig()
     config.logToFile = cConfig.log_to_file != 0;
     config.logTruncationAt = cConfig.log_truncation_at;
     config.maxMemoryUsage = cConfig.max_memory_usage;
+    config.unifiedMemtable = cConfig.unified_memtable != 0;
+    config.unifiedMemtableWriteBufferSize = cConfig.unified_memtable_write_buffer_size;
+    config.unifiedMemtableSkipListMaxLevel = cConfig.unified_memtable_skip_list_max_level;
+    config.unifiedMemtableSkipListProbability = cConfig.unified_memtable_skip_list_probability;
+    config.unifiedMemtableSyncMode = static_cast<SyncMode>(cConfig.unified_memtable_sync_mode);
+    config.unifiedMemtableSyncIntervalUs = cConfig.unified_memtable_sync_interval_us;
 
     return config;
 }

--- a/tests/tidesdb_test.cpp
+++ b/tests/tidesdb_test.cpp
@@ -1478,6 +1478,164 @@ TEST_F(TidesDBTest, CommitHookViaConfig)
     ASSERT_GE(hookCtx.totalOps.load(), 1);
 }
 
+TEST_F(TidesDBTest, DeleteColumnFamily)
+{
+    tidesdb::TidesDB db(getConfig());
+
+    auto cfConfig = tidesdb::ColumnFamilyConfig::defaultConfig();
+    db.createColumnFamily("to_delete_cf", cfConfig);
+
+    auto cf = db.getColumnFamily("to_delete_cf");
+
+    // Write some data
+    {
+        auto txn = db.beginTransaction();
+        txn.put(cf, "key1", "value1", -1);
+        txn.commit();
+    }
+
+    // Delete by handle
+    db.deleteColumnFamily(cf);
+
+    // Should no longer exist
+    EXPECT_THROW(db.getColumnFamily("to_delete_cf"), tidesdb::Exception);
+}
+
+TEST_F(TidesDBTest, IteratorKeyValue)
+{
+    tidesdb::TidesDB db(getConfig());
+
+    auto cfConfig = tidesdb::ColumnFamilyConfig::defaultConfig();
+    db.createColumnFamily("test_cf", cfConfig);
+
+    auto cf = db.getColumnFamily("test_cf");
+
+    {
+        auto txn = db.beginTransaction();
+        txn.put(cf, "key1", "value1", -1);
+        txn.put(cf, "key2", "value2", -1);
+        txn.put(cf, "key3", "value3", -1);
+        txn.commit();
+    }
+
+    {
+        auto txn = db.beginTransaction();
+        auto iter = txn.newIterator(cf);
+        iter.seekToFirst();
+
+        int count = 0;
+        while (iter.valid())
+        {
+            auto [key, value] = iter.keyValue();
+            std::string keyStr(key.begin(), key.end());
+            std::string valueStr(value.begin(), value.end());
+
+            ASSERT_FALSE(keyStr.empty());
+            ASSERT_FALSE(valueStr.empty());
+
+            count++;
+            iter.next();
+        }
+
+        ASSERT_EQ(count, 3);
+    }
+}
+
+TEST_F(TidesDBTest, UnifiedMemtableConfig)
+{
+    tidesdb::Config config;
+    config.dbPath = testDbPath_;
+    config.numFlushThreads = 2;
+    config.numCompactionThreads = 2;
+    config.logLevel = tidesdb::LogLevel::Info;
+    config.blockCacheSize = 64 * 1024 * 1024;
+    config.maxOpenSSTables = 256;
+    config.unifiedMemtable = true;
+    config.unifiedMemtableWriteBufferSize = 32 * 1024 * 1024;
+    config.unifiedMemtableSkipListMaxLevel = 16;
+    config.unifiedMemtableSkipListProbability = 0.25f;
+    config.unifiedMemtableSyncMode = tidesdb::SyncMode::None;
+    config.unifiedMemtableSyncIntervalUs = 0;
+
+    tidesdb::TidesDB db(config);
+
+    auto cfConfig = tidesdb::ColumnFamilyConfig::defaultConfig();
+    db.createColumnFamily("test_cf", cfConfig);
+
+    auto cf = db.getColumnFamily("test_cf");
+
+    // Write and read data with unified memtable mode
+    {
+        auto txn = db.beginTransaction();
+        txn.put(cf, "ukey", "uvalue", -1);
+        txn.commit();
+    }
+
+    {
+        auto txn = db.beginTransaction();
+        auto value = txn.get(cf, "ukey");
+        std::string valueStr(value.begin(), value.end());
+        ASSERT_EQ(valueStr, "uvalue");
+    }
+}
+
+TEST_F(TidesDBTest, DbStatsUnifiedFields)
+{
+    tidesdb::Config config;
+    config.dbPath = testDbPath_;
+    config.numFlushThreads = 2;
+    config.numCompactionThreads = 2;
+    config.logLevel = tidesdb::LogLevel::Info;
+    config.blockCacheSize = 64 * 1024 * 1024;
+    config.maxOpenSSTables = 256;
+    config.unifiedMemtable = true;
+
+    tidesdb::TidesDB db(config);
+
+    auto cfConfig = tidesdb::ColumnFamilyConfig::defaultConfig();
+    db.createColumnFamily("test_cf", cfConfig);
+
+    auto dbStats = db.getDbStats();
+
+    ASSERT_TRUE(dbStats.unifiedMemtableEnabled);
+    ASSERT_FALSE(dbStats.objectStoreEnabled);
+    ASSERT_FALSE(dbStats.replicaMode);
+}
+
+TEST_F(TidesDBTest, ErrorCodeReadonly)
+{
+    // Verify the Readonly error code maps correctly
+    ASSERT_EQ(static_cast<int>(tidesdb::ErrorCode::Readonly), TDB_ERR_READONLY);
+    ASSERT_EQ(static_cast<int>(tidesdb::ErrorCode::Readonly), -13);
+
+    // Verify error message
+    std::string msg = tidesdb::Exception::errorMessage(TDB_ERR_READONLY);
+    ASSERT_EQ(msg, "database is read-only");
+}
+
+TEST_F(TidesDBTest, DefaultConfigUnifiedFields)
+{
+    auto defaultConfig = tidesdb::TidesDB::defaultConfig();
+
+    // Default should have unified memtable disabled
+    ASSERT_FALSE(defaultConfig.unifiedMemtable);
+    ASSERT_EQ(defaultConfig.unifiedMemtableWriteBufferSize, 0u);
+    ASSERT_EQ(defaultConfig.unifiedMemtableSkipListMaxLevel, 0);
+    ASSERT_EQ(defaultConfig.unifiedMemtableSkipListProbability, 0.0f);
+    ASSERT_EQ(defaultConfig.unifiedMemtableSyncMode, tidesdb::SyncMode::None);
+    ASSERT_EQ(defaultConfig.unifiedMemtableSyncIntervalUs, 0u);
+}
+
+TEST_F(TidesDBTest, ColumnFamilyConfigObjectStoreFields)
+{
+    auto cfConfig = tidesdb::ColumnFamilyConfig::defaultConfig();
+
+    // Verify object store fields are populated from C defaults
+    ASSERT_GT(cfConfig.objectTargetFileSize, 0u);  // default 256MB
+    ASSERT_GE(cfConfig.objectLazyCompaction, 0);
+    ASSERT_GE(cfConfig.objectPrefetchCompaction, 0);
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
… stats object store/replica fields, delete column family by handle, promote to primary, iterator key-value, readonly error code, cf object store fields; bump to 2.3.6